### PR TITLE
use existing `poll` field to allow for configurable interval -- fixes #2

### DIFF
--- a/src/main/java/org/springframework/boot/actuator/splunk/ActuatorPoller.java
+++ b/src/main/java/org/springframework/boot/actuator/splunk/ActuatorPoller.java
@@ -55,7 +55,7 @@ public class ActuatorPoller {
                 while (thread != null) {
 
                     try {
-                        Thread.sleep(10000L);
+                        Thread.sleep(poll);
                     } catch (InterruptedException e) {
                         break;
                     }


### PR DESCRIPTION
The `poll` variable already existed, I guess it was just never put in place (I assume it was an oversight).